### PR TITLE
Add polymorphic Hooks.useAdaptive for cset/clist/cmap

### DIFF
--- a/src/Fable.React.Adaptive/Hooks.fs
+++ b/src/Fable.React.Adaptive/Hooks.fs
@@ -60,4 +60,15 @@ module AdaptiveExtensions =
         member inline x.useAdaptive (value: alist<'T>) =
             x.useAdaptive value.Content
 
+        /// uses the given cset as react-state-hook
+        member inline x.useAdaptive (value: cset<'T>) =
+            x.useAdaptive (value :> aset<'T>).Content
+
+        /// uses the given amap as react-state-hook
+        member inline x.useAdaptive (value: cmap<'K, 'V>) =
+            x.useAdaptive (value :> amap<'K, 'V>).Content
+
+        /// uses the given alist as react-state-hook
+        member inline x.useAdaptive (value: clist<'T>) =
+            x.useAdaptive (value :> alist<'T>).Content
 

--- a/src/Fable.React.Adaptive/Hooks.fs
+++ b/src/Fable.React.Adaptive/Hooks.fs
@@ -64,11 +64,11 @@ module AdaptiveExtensions =
         member inline x.useAdaptive (value: cset<'T>) =
             x.useAdaptive (value :> aset<'T>).Content
 
-        /// uses the given amap as react-state-hook
+        /// uses the given cmap as react-state-hook
         member inline x.useAdaptive (value: cmap<'K, 'V>) =
             x.useAdaptive (value :> amap<'K, 'V>).Content
 
-        /// uses the given alist as react-state-hook
+        /// uses the given clist as react-state-hook
         member inline x.useAdaptive (value: clist<'T>) =
             x.useAdaptive (value :> alist<'T>).Content
 


### PR DESCRIPTION
Hooks.useAdaptive has issues with changeable data structures (compiler can't determine wheather to cast `clist` into `alist` or directly into `aval`), so I've added explicit casts.